### PR TITLE
Fix Keras RS object serialization.

### DIFF
--- a/keras_rs/src/api_export.py
+++ b/keras_rs/src/api_export.py
@@ -13,12 +13,11 @@ T = TypeVar("T", bound=Any)
 
 class keras_rs_export:
     def __init__(self, path: str):
-        self.path = path
         if namex is not None:
             self.namex_export = namex.export(package="keras_rs", path=path)
 
     def __call__(self, symbol: T) -> T:
-        keras.saving.register_keras_serializable(self.path, symbol)
+        keras.saving.register_keras_serializable(package="keras_rs")(symbol)
         if namex is not None:
             self.namex_export(symbol)
         return symbol


### PR DESCRIPTION
The `keras_rs_export` decorator was not calling `register_keras_serializable` correctly.