### PR TITLE
Fix dot interaction

### DIFF
--- a/keras_rs/src/layers/modeling/dot_interaction.py
+++ b/keras_rs/src/layers/modeling/dot_interaction.py
@@ -5,7 +5,7 @@ from keras import ops
 
 from keras_rs.src import types
 from keras_rs.src.api_export import keras_rs_export
-from keras_rs.src.utils.keras_utils import check_shape
+from keras_rs.src.utils.keras_utils import check_shapes_compatible
 
 
 @keras_rs_export("keras_rs.layers.DotInteraction")
@@ -111,7 +111,7 @@ class DotInteraction(keras.layers.Layer):
                     f"Received rank {len(shape)} at index {idx}."
                 )
 
-            if not check_shape(shape, other_shape):
+            if not check_shapes_compatible(shape, other_shape):
                 raise ValueError(
                     "All feature tensors in `inputs` should have the same "
                     f"shape. Found at least one conflict: shape = {shape} at "
@@ -139,11 +139,17 @@ class DotInteraction(keras.layers.Layer):
                 ops.cast(tril_mask, dtype=pairwise_interaction_matrix.dtype),
             )
             # Rank-2 tensor.
-            activations = ops.reshape(activations, (batch_size, -1))
+            activations = ops.reshape(
+                activations, (batch_size, num_features * num_features)
+            )
         else:
             flattened_indices = self._get_lower_triangular_indices(num_features)
+            pairwise_interaction_matrix_flattened = ops.reshape(
+                pairwise_interaction_matrix,
+                (batch_size, num_features * num_features),
+            )
             activations = ops.take(
-                ops.reshape(pairwise_interaction_matrix, (batch_size, -1)),
+                pairwise_interaction_matrix_flattened,
                 flattened_indices,
                 axis=-1,
             )

--- a/keras_rs/src/layers/modeling/dot_interaction.py
+++ b/keras_rs/src/layers/modeling/dot_interaction.py
@@ -128,7 +128,6 @@ class DotInteraction(keras.layers.Layer):
         pairwise_interaction_matrix = ops.matmul(
             features, ops.transpose(features, axes=(0, 2, 1))
         )
-        print(pairwise_interaction_matrix)
 
         # Set the upper triangle entries to 0, if `self.skip_gather` is True.
         # Else, "pick" only the lower triangle entries.

--- a/keras_rs/src/layers/modeling/dot_interaction_test.py
+++ b/keras_rs/src/layers/modeling/dot_interaction_test.py
@@ -75,6 +75,8 @@ class DotInteractionTest(testing.TestCase, parameterized.TestCase):
         ),
     )
     def test_call(self, self_interaction, skip_gather, exp_output_idx):
+        print(self.input)
+        self.assertEqual(0, 1)
         layer = DotInteraction(
             self_interaction=self_interaction, skip_gather=skip_gather
         )

--- a/keras_rs/src/layers/modeling/dot_interaction_test.py
+++ b/keras_rs/src/layers/modeling/dot_interaction_test.py
@@ -75,8 +75,6 @@ class DotInteractionTest(testing.TestCase, parameterized.TestCase):
         ),
     )
     def test_call(self, self_interaction, skip_gather, exp_output_idx):
-        print(self.input)
-        self.assertEqual(0, 1)
         layer = DotInteraction(
             self_interaction=self_interaction, skip_gather=skip_gather
         )

--- a/keras_rs/src/layers/modeling/dot_interaction_test.py
+++ b/keras_rs/src/layers/modeling/dot_interaction_test.py
@@ -100,6 +100,40 @@ class DotInteractionTest(testing.TestCase, parameterized.TestCase):
         restored = deserialize(serialize(layer))
         self.assertDictEqual(layer.get_config(), restored.get_config())
 
+    @parameterized.named_parameters(
+        (
+            "self_interaction_false_skip_gather_false",
+            False,
+            False,
+        ),
+        (
+            "self_interaction_false_skip_gather_true",
+            False,
+            True,
+        ),
+        (
+            "self_interaction_true_skip_gather_false",
+            True,
+            False,
+        ),
+        (
+            "self_interaction_true_skip_gather_true",
+            True,
+            True,
+        ),
+    )
+    def test_predict(self, self_interaction, skip_gather):
+        feature1 = keras.layers.Input(shape=(5,))
+        feature2 = keras.layers.Input(shape=(5,))
+        feature3 = keras.layers.Input(shape=(5,))
+        x = DotInteraction(
+            self_interaction=self_interaction, skip_gather=skip_gather
+        )([feature1, feature2, feature3])
+        x = keras.layers.Dense(units=1)(x)
+        model = keras.Model([feature1, feature2, feature3], x)
+
+        model.predict(self.input)
+
     def test_model_saving(self):
         feature1 = keras.layers.Input(shape=(5,))
         feature2 = keras.layers.Input(shape=(5,))

--- a/keras_rs/src/utils/keras_utils.py
+++ b/keras_rs/src/utils/keras_utils.py
@@ -2,6 +2,8 @@ from typing import Union
 
 import keras
 
+from keras_rs.src import types
+
 
 def clone_initializer(
     initializer: Union[str, keras.initializers.Initializer],
@@ -25,3 +27,16 @@ def clone_initializer(
         return initializer_class.from_config(config)
     # If we get a string or dict, just return as we cannot and should not clone.
     return initializer
+
+
+def check_shape(shape1: types.TensorShape, shape2: types.TensorShape) -> bool:
+    # Check rank first.
+    if len(shape1) != len(shape2):
+        return False
+
+    for d1, d2 in zip(shape1, shape2):
+        if isinstance(d1, int) and isinstance(d2, int):
+            if d1 != d2:
+                return False
+
+    return True

--- a/keras_rs/src/utils/keras_utils.py
+++ b/keras_rs/src/utils/keras_utils.py
@@ -29,7 +29,9 @@ def clone_initializer(
     return initializer
 
 
-def check_shape(shape1: types.TensorShape, shape2: types.TensorShape) -> bool:
+def check_shapes_compatible(
+    shape1: types.TensorShape, shape2: types.TensorShape
+) -> bool:
     # Check rank first.
     if len(shape1) != len(shape2):
         return False


### PR DESCRIPTION
- Using `tril_mask` to pick the lower triangular part of the matrix does not work for JAX when `skip_gather` is `False`. So, we generate indices and then index into the array.
- Cannot compare shapes directly.