### PR TITLE
Use `ml_dtypes` instead of `numpy` for `finfo`.

### DIFF
--- a/keras_rs/src/layers/retrieval/hard_negative_mining.py
+++ b/keras_rs/src/layers/retrieval/hard_negative_mining.py
@@ -1,13 +1,13 @@
 from typing import Any
 
 import keras
-import numpy as np
+import ml_dtypes
 from keras import ops
 
 from keras_rs.src import types
 from keras_rs.src.api_export import keras_rs_export
 
-MAX_FLOAT = np.finfo(np.float32).max / 100.0
+MAX_FLOAT = ml_dtypes.finfo("float32").max / 100.0
 
 
 def _gather_elements_along_row(

--- a/keras_rs/src/layers/retrieval/remove_accidental_hits.py
+++ b/keras_rs/src/layers/retrieval/remove_accidental_hits.py
@@ -1,12 +1,12 @@
 import keras
-import numpy as np
+import ml_dtypes
 from keras import ops
 
 from keras_rs.src import types
 from keras_rs.src.api_export import keras_rs_export
 from keras_rs.src.utils import keras_utils
 
-SMALLEST_FLOAT = np.finfo(np.float32).smallest_normal / 100.0
+SMALLEST_FLOAT = ml_dtypes.finfo("float32").smallest_normal / 100.0
 
 
 @keras_rs_export("keras_rs.layers.RemoveAccidentalHits")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "keras",
+    "ml-dtypes",
 ]
 
 [project.urls]
@@ -60,6 +61,7 @@ known-first-party = ["keras_rs"]
 [tool.mypy]
 strict = "True"
 exclude = ["_test\\.py$", "^examples"]
+untyped_calls_exclude = ["ml_dtypes"]
 disable_error_code = ["import-untyped"]
 disallow_subclassing_any = "False"
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,5 +14,6 @@ numpy
 # pip build
 build
 
-# keras
+# required dependencies, should match dependencies in pyproject.toml
 keras
+ml-dtypes


### PR DESCRIPTION
This is consistent with Keras' usage of `ml_dtypes`.

Also added `ml_dtypes` as a pip package dependency.