### PR TITLE
Fix disabling of traceback filtering in unit test.

### DIFF
--- a/keras_rs/src/testing/test_case.py
+++ b/keras_rs/src/testing/test_case.py
@@ -14,8 +14,8 @@ class TestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        keras.config.disable_traceback_filtering()
         keras.utils.clear_session()
+        keras.config.disable_traceback_filtering()
 
     def assertAllClose(
         self,


### PR DESCRIPTION
`keras.utils.clear_session()` actually clears that flag.