### PR TITLE
Remove `torchvision` from requirements files.

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -4,7 +4,6 @@ tensorflow-cpu
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.1.0
-torchvision>=0.16.0
 
 # Jax with cuda support.
 # Keep same version as Keras repo.

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -4,7 +4,6 @@ tensorflow[and-cuda]~=2.17.0
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.1.0
-torchvision>=0.16.0
 
 # Jax cpu-only version.
 jax[cpu]

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -4,7 +4,6 @@ tensorflow-cpu~=2.17
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch==2.6.0
-torchvision==0.19.1+cu121
 
 # Jax cpu-only version.
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ tensorflow~=2.18.0;sys_platform == 'darwin'
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.1.0
-torchvision>=0.16.0
 
 # Jax.
 jax[cpu]


### PR DESCRIPTION
They are not needed and were removed from the Keras requirements files.