### PR TITLE
Cast tensors to the correct dtype for metrics

### DIFF
--- a/keras_rs/src/metrics/mean_average_precision.py
+++ b/keras_rs/src/metrics/mean_average_precision.py
@@ -25,7 +25,7 @@ class MeanAveragePrecision(RankingMetric):
     ) -> types.Tensor:
         relevance = ops.cast(
             ops.greater_equal(y_true, ops.cast(1, dtype=y_true.dtype)),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         sorted_relevance, sorted_weights = sort_by_scores(
             tensors_to_sort=[relevance, sample_weight],

--- a/keras_rs/src/metrics/mean_reciprocal_rank.py
+++ b/keras_rs/src/metrics/mean_reciprocal_rank.py
@@ -44,13 +44,13 @@ class MeanReciprocalRank(RankingMetric):
             ops.greater_equal(
                 sorted_y_true, ops.cast(1, dtype=sorted_y_true.dtype)
             ),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
 
         # `reciprocal_rank = [1, 0.5, 0.33]`
         reciprocal_rank = ops.divide(
-            ops.cast(1, dtype="float32"),
-            ops.arange(1, list_length + 1, dtype="float32"),
+            ops.cast(1, dtype=y_pred.dtype),
+            ops.arange(1, list_length + 1, dtype=y_pred.dtype),
         )
 
         # `mrr` should be of shape `(batch_size, 1)`.
@@ -64,7 +64,7 @@ class MeanReciprocalRank(RankingMetric):
         # Get weights.
         overall_relevance = ops.cast(
             ops.greater_equal(y_true, ops.cast(1, dtype=y_true.dtype)),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         per_list_weights = get_list_weights(
             weights=sample_weight, relevance=overall_relevance

--- a/keras_rs/src/metrics/precision_at_k.py
+++ b/keras_rs/src/metrics/precision_at_k.py
@@ -40,7 +40,7 @@ class PrecisionAtK(RankingMetric):
             ops.greater_equal(
                 sorted_y_true, ops.cast(1, dtype=sorted_y_true.dtype)
             ),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         list_length = ops.shape(sorted_y_true)[1]
         # TODO: We do not do this for MRR, and the other metrics. Do we need to
@@ -52,13 +52,13 @@ class PrecisionAtK(RankingMetric):
 
         per_list_precision = ops.divide_no_nan(
             ops.sum(relevance, axis=1, keepdims=True),
-            ops.cast(valid_list_length, dtype="float32"),
+            ops.cast(valid_list_length, dtype=y_pred.dtype),
         )
 
         # Get weights.
         overall_relevance = ops.cast(
             ops.greater_equal(y_true, ops.cast(1, dtype=y_true.dtype)),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         per_list_weights = get_list_weights(
             weights=sample_weight, relevance=overall_relevance

--- a/keras_rs/src/metrics/ranking_metric.py
+++ b/keras_rs/src/metrics/ranking_metric.py
@@ -116,6 +116,12 @@ class RankingMetric(keras.metrics.Mean, abc.ABC):
         if passed_mask is not None:
             passed_mask = ops.convert_to_tensor(passed_mask)
 
+        # Cast to the correct dtype.
+        y_true = ops.cast(y_true, dtype=self.dtype)
+        y_pred = ops.cast(y_pred, dtype=self.dtype)
+        if sample_weight is not None:
+            sample_weight = ops.cast(sample_weight, dtype=self.dtype)
+
         # === Process `sample_weight` ===
         if sample_weight is None:
             sample_weight = ops.cast(1, dtype=y_pred.dtype)
@@ -152,7 +158,7 @@ class RankingMetric(keras.metrics.Mean, abc.ABC):
 
         # Mask all values less than 0 (since less than 0 implies invalid
         # labels).
-        valid_mask = ops.greater_equal(y_true, ops.cast(0.0, y_true.dtype))
+        valid_mask = ops.greater_equal(y_true, ops.cast(0, y_true.dtype))
         if passed_mask is not None:
             valid_mask = ops.logical_and(valid_mask, passed_mask)
 

--- a/keras_rs/src/metrics/ranking_metrics_utils.py
+++ b/keras_rs/src/metrics/ranking_metrics_utils.py
@@ -163,7 +163,7 @@ def get_list_weights(
     # Identify lists where both weights and relevance sums are non-zero.
     nonzero_relevance = ops.cast(
         ops.logical_and(nonzero_weights, nonzero_relevance_condition),
-        dtype="float32",
+        dtype=weights.dtype,
     )
     # Count the number of lists with non-zero relevance and non-zero weights.
     nonzero_relevance_count = ops.sum(nonzero_relevance, axis=0, keepdims=True)
@@ -227,7 +227,7 @@ def compute_dcg(
     ] = default_rank_discount_fn,
 ) -> types.Tensor:
     list_size = ops.shape(y_true)[1]
-    positions = ops.arange(1, list_size + 1, dtype="float32")
+    positions = ops.arange(1, list_size + 1, dtype=y_true.dtype)
     gain = gain_fn(y_true)
     discount = rank_discount_fn(positions)
 

--- a/keras_rs/src/metrics/recall_at_k.py
+++ b/keras_rs/src/metrics/recall_at_k.py
@@ -38,11 +38,11 @@ class RecallAtK(RankingMetric):
             ops.greater_equal(
                 sorted_y_true, ops.cast(1, dtype=sorted_y_true.dtype)
             ),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         overall_relevance = ops.cast(
             ops.greater_equal(y_true, ops.cast(1, dtype=y_true.dtype)),
-            dtype="float32",
+            dtype=y_pred.dtype,
         )
         per_list_recall = ops.divide_no_nan(
             ops.sum(relevance, axis=1, keepdims=True),


### PR DESCRIPTION
I know we'd discussed that we can probably do

```
keras.backend.result_dtype(y_true.dtype, y_pred.dtype)
```

but looks like this is the correct way to do it? Just use `self.dtype`