### PR TITLE
Change main version to 0.1.1.dev0

### DIFF
--- a/keras_rs/src/version.py
+++ b/keras_rs/src/version.py
@@ -1,7 +1,7 @@
 from keras_rs.src.api_export import keras_rs_export
 
 # Unique source of truth for the version number.
-__version__ = "0.1.1"
+__version__ = "0.1.1.dev0"
 
 
 @keras_rs_export("keras_rs.version")


### PR DESCRIPTION
The version on main should be a dev version, because sometimes, people accidentally cut a release on `main`, which results in a release. If we set the version to a dev version, it'll just be a pre-release even by accident.

(this is how we do it on KerasHub too)