### PR TITLE
Add `no_automatic_dependency_tracking` utility.

### DIFF
--- a/keras_rs/src/metrics/ranking_metrics_utils.py
+++ b/keras_rs/src/metrics/ranking_metrics_utils.py
@@ -63,7 +63,7 @@ def sort_by_scores(
     Utility function for sorting tensors by scores.
 
     Args:
-        tensors_to_sort. list of tensors. All tensors are of shape
+        tensors_to_sort: list of tensors. All tensors are of shape
             `(batch_size, list_size)`. These tensors are sorted based on
             `scores`.
         scores: tensor. Of shape `(batch_size, list_size)`. The scores to sort

--- a/keras_rs/src/utils/keras_utils.py
+++ b/keras_rs/src/utils/keras_utils.py
@@ -1,8 +1,30 @@
-from typing import Union
+from typing import Any, Callable, Union
 
 import keras
 
 from keras_rs.src import types
+
+
+def no_automatic_dependency_tracking(
+    fn: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Decorator to disable automatic dependency tracking in Keras and TF.
+
+    Args:
+        fn: the function to disable automatic dependency tracking for.
+
+    Returns:
+        a wrapped version of `fn`.
+    """
+    if keras.backend.backend() == "tensorflow":
+        import tensorflow as tf
+
+        fn = tf.__internal__.tracking.no_automatic_dependency_tracking(fn)
+
+    wrapped_fn: Callable[..., Any] = (
+        keras.src.utils.tracking.no_automatic_dependency_tracking(fn)
+    )
+    return wrapped_fn
 
 
 def clone_initializer(


### PR DESCRIPTION
This wraps the private equivalent decorators in Keras and TensorFlow.