### PR TITLE
Added `TensorShape` alias for the recently renamed `Shape`.

### DIFF
--- a/keras_rs/src/types.py
+++ b/keras_rs/src/types.py
@@ -35,6 +35,7 @@ Union[
 Tensor = Any
 
 Shape = Sequence[Optional[int]]
+TensorShape = Shape
 
 DType = str
 


### PR DESCRIPTION
For temporary backwards compatibility.