### PR TITLE
Fix embed_reduce for sparse inputs.

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -15,7 +15,5 @@ numpy
 build
 
 # required dependencies, should match dependencies in pyproject.toml
-# TODO revert. Needed to get keras-nightly until 3.10 is released.
-# keras
-keras-nightly
+keras
 ml-dtypes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 # Tensorflow.
-# TODO revert. Needed to get keras-nightly until 3.10 is released.
-# tensorflow-cpu~=2.18.0;sys_platform != 'darwin'
-# tensorflow~=2.18.0;sys_platform == 'darwin'
-tf-nightly-cpu;sys_platform != 'darwin'
-tf-nightly;sys_platform == 'darwin'
+tensorflow-cpu~=2.18.0;sys_platform != 'darwin'
+tensorflow~=2.18.0;sys_platform == 'darwin'
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Unfortunately `keras.ops.ones_like` discards the sparsity pattern for sparse tensors, instead filling a dense tensor with the same overall shape.

There don't seem to be any standard utilities in Keras for manipulating sparse tensors across multiple backends.  All math functions that operate on sparse tensors intentionally treat explicit `0`s the same as implicit zeros, preventing us from using math tricks to get a sparse tensor of ones.  So, we resort to adding backend-specific checks here.

Currently only TF and JAX are supported.