### PR TITLE
Add backend/hardware-independent doc for `DistributedEmbedding`.

### DIFF
--- a/keras_rs/src/layers/embedding/distributed_embedding_config.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding_config.py
@@ -1,7 +1,7 @@
 """Configuration for TPU embedding layer."""
 
 import dataclasses
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import keras
 
@@ -51,10 +51,8 @@ class TableConfig:
     name: str
     vocabulary_size: int
     embedding_dim: int
-    initializer: Optional[Union[str, keras.initializers.Initializer]] = (
-        keras.initializers.VarianceScaling(
-            scale=1.0, mode="fan_out", distribution="truncated_normal"
-        )
+    initializer: Union[str, keras.initializers.Initializer] = (
+        keras.initializers.VarianceScaling(mode="fan_out")
     )
     optimizer: Union[str, keras.optimizers.Optimizer] = "adam"
     combiner: str = "mean"

--- a/keras_rs/src/layers/embedding/embed_reduce.py
+++ b/keras_rs/src/layers/embedding/embed_reduce.py
@@ -127,7 +127,7 @@ class EmbedReduce(keras.layers.Embedding):
             single row. Currently `mean`, `sqrtn` and `sum` are supported.
             `mean` is the default. `sqrtn` often achieves good accuracy, in
             particular with bag-of-words columns.
-      **kwargs: Additional keyword arguments passed to `Embedding`.
+        **kwargs: Additional keyword arguments passed to `Embedding`.
     """
 
     def __init__(


### PR DESCRIPTION
Specific TF and JAX documentation will be added with support.

Also:
- fixed `EmbedReduce` doc rendering
- simplified `TableConfig` default initializer by removing parameter that is the default