### PR TITLE
Ignore shard_map attr error in mypy.

### DIFF
--- a/keras_rs/src/layers/embedding/jax/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding.py
@@ -30,7 +30,7 @@ from keras_rs.src.utils import keras_utils
 
 ArrayLike = Union[np.ndarray[Any, Any], jax.Array]
 FeatureConfig = config.FeatureConfig
-shard_map = jax.experimental.shard_map.shard_map
+shard_map = jax.experimental.shard_map.shard_map  # type: ignore[attr-defined]
 
 
 def _get_partition_spec(

--- a/keras_rs/src/layers/embedding/jax/embedding_lookup.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_lookup.py
@@ -16,7 +16,7 @@ from jax_tpu_embedding.sparsecore.utils import utils as jte_utils
 from keras_rs.src.layers.embedding.jax import embedding_utils
 
 ShardedCooMatrix = embedding_utils.ShardedCooMatrix
-shard_map = jax.experimental.shard_map.shard_map
+shard_map = jax.experimental.shard_map.shard_map  # type: ignore[attr-defined]
 
 T = TypeVar("T")
 Nested = Union[T, Sequence[T], Mapping[str, T]]


### PR DESCRIPTION
The function does still exist in `jax.experimental.shard_map`, but is an alias in the latest JAX version.  Since we support older JAX versions (i.e. 0.6.0), we need to keep the original reference.