### PR TITLE
`api_gen` now excludes backend specific code.

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -54,7 +54,14 @@ def build() -> None:
         os.chdir(build_dir)
         # Generates `keras_rs/api` directory.
         open(build_api_init_fname, "w").close()
-        namex.generate_api_files("keras_rs", code_directory="src")
+        namex.generate_api_files(
+            "keras_rs",
+            code_directory="src",
+            exclude_directories=[
+                os.path.join("src", "layers", "embedding", "jax"),
+                os.path.join("src", "layers", "embedding", "tensorflow"),
+            ],
+        )
         # Add `__version__` to `keras_rs/__init__.py`.
         export_version_string(build_api_init_fname)
         # Copy back `keras_rs` from build dir to `api` excluding `src/`.


### PR DESCRIPTION
This:
- Allows development (`api_gen` / git presubmit hooks) without all backends and backend specific dependencies installed and working. For instance, jax_tpu_embedding currently doesn't import on MacOS Sequoia, this allows running `api_gen` regardless.
- Makes sure we don't accidentally create and honor exports that are backend specific.