### PR TITLE
Use Python 3.10 style type annotations.

### DIFF
--- a/keras_rs/src/layers/embedding/base_distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/base_distributed_embedding.py
@@ -1,6 +1,6 @@
 import collections
 import typing
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Sequence
 
 import keras
 from keras.src import backend
@@ -248,9 +248,9 @@ class DistributedEmbedding(keras.layers.Layer):
         self,
         feature_configs: types.Nested[FeatureConfig],
         *,
-        table_stacking: Union[
-            str, Sequence[str], Sequence[Sequence[str]]
-        ] = "auto",
+        table_stacking: (
+            str | Sequence[str] | Sequence[Sequence[str]]
+        ) = "auto",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -406,7 +406,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def preprocess(
         self,
         inputs: types.Nested[types.Tensor],
-        weights: Optional[types.Nested[types.Tensor]] = None,
+        weights: types.Nested[types.Tensor] | None = None,
         training: bool = False,
     ) -> types.Nested[types.Tensor]:
         """Preprocesses and reformats the data for consumption by the model.
@@ -530,7 +530,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def call(
         self,
         inputs: types.Nested[types.Tensor],
-        weights: Optional[types.Nested[types.Tensor]] = None,
+        weights: types.Nested[types.Tensor] | None = None,
         training: bool = False,
     ) -> types.Nested[types.Tensor]:
         """Lookup features in embedding tables and apply reduction.
@@ -619,8 +619,8 @@ class DistributedEmbedding(keras.layers.Layer):
 
     def _default_device_init(
         self,
-        feature_configs: dict[str, Union[FeatureConfig]],
-        table_stacking: Union[str, Sequence[Sequence[str]]],
+        feature_configs: dict[str, FeatureConfig],
+        table_stacking: str | Sequence[Sequence[str]],
     ) -> None:
         del table_stacking
         table_to_embedding_layer: dict[TableConfig, EmbedReduce] = {}
@@ -653,7 +653,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def _default_device_preprocess(
         self,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]],
+        weights: dict[str, types.Tensor] | None,
         training: bool = False,
     ) -> dict[str, types.Tensor]:
         del training
@@ -666,7 +666,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def _default_device_call(
         self,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]] = None,
+        weights: dict[str, types.Tensor] | None = None,
         training: bool = False,
     ) -> dict[str, types.Tensor]:
         del training  # Unused by default.
@@ -699,7 +699,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def _sparsecore_init(
         self,
         feature_configs: dict[str, FeatureConfig],
-        table_stacking: Union[str, Sequence[Sequence[str]]],
+        table_stacking: str | Sequence[Sequence[str]],
     ) -> None:
         del feature_configs, table_stacking
         raise self._unsupported_placement_error("sparsecore")
@@ -711,7 +711,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def _sparsecore_preprocess(
         self,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]],
+        weights: dict[str, types.Tensor] | None,
         training: bool = False,
     ) -> dict[str, types.Tensor]:
         del training
@@ -724,7 +724,7 @@ class DistributedEmbedding(keras.layers.Layer):
     def _sparsecore_call(
         self,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]] = None,
+        weights: dict[str, types.Tensor] | None = None,
         training: bool = False,
     ) -> dict[str, types.Tensor]:
         del inputs, weights, training
@@ -792,13 +792,13 @@ class DistributedEmbedding(keras.layers.Layer):
         # The serialized `TableConfig` objects.
         table_config_dicts: list[dict[str, Any]] = config.pop("tables")
         # The deserialized `TableConfig` objects at the same indices.
-        table_configs: list[Optional[TableConfig]] = [None] * len(
+        table_configs: list[TableConfig | None] = [None] * len(
             table_config_dicts
         )
 
         def deserialize_feature_config(
             feature_config_dict: dict[str, Any],
-        ) -> Optional[FeatureConfig]:
+        ) -> FeatureConfig | None:
             # Look for a "name" attribute which is a string to detect a
             # `FeatureConfig` leaf node. If not, keep recursing.
             if "name" not in feature_config_dict or not isinstance(

--- a/keras_rs/src/layers/embedding/distributed_embedding_config.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding_config.py
@@ -1,7 +1,7 @@
 """Configuration for TPU embedding layer."""
 
 import dataclasses
-from typing import Any, Union
+from typing import Any
 
 import keras
 
@@ -51,10 +51,10 @@ class TableConfig:
     name: str
     vocabulary_size: int
     embedding_dim: int
-    initializer: Union[str, keras.initializers.Initializer] = (
+    initializer: str | keras.initializers.Initializer = (
         keras.initializers.VarianceScaling(mode="fan_out")
     )
-    optimizer: Union[str, keras.optimizers.Optimizer] = "adam"
+    optimizer: str | keras.optimizers.Optimizer = "adam"
     combiner: str = "mean"
     placement: str = "auto"
     max_ids_per_partition: int = 256

--- a/keras_rs/src/layers/embedding/embed_reduce.py
+++ b/keras_rs/src/layers/embedding/embed_reduce.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import keras
 from keras import ops
@@ -34,7 +34,7 @@ def _is_supported_sparse(x: types.Tensor) -> bool:
 
 
 def _sparse_ones_like(
-    x: types.Tensor, dtype: Optional[types.DType] = None
+    x: types.Tensor, dtype: types.DType | None = None
 ) -> types.Tensor:
     """Creates a tensor of ones with the same sparsity as the input.
 
@@ -135,8 +135,8 @@ class EmbedReduce(keras.layers.Embedding):
         input_dim: int,
         output_dim: int,
         embeddings_initializer: types.InitializerLike = "uniform",
-        embeddings_regularizer: Optional[types.RegularizerLike] = None,
-        embeddings_constraint: Optional[types.ConstraintLike] = None,
+        embeddings_regularizer: types.RegularizerLike | None = None,
+        embeddings_constraint: types.ConstraintLike | None = None,
         mask_zero: bool = False,
         weights: types.Tensor = None,
         combiner: str = "mean",
@@ -162,7 +162,7 @@ class EmbedReduce(keras.layers.Embedding):
     def call(
         self,
         inputs: types.Tensor,
-        weights: Optional[types.Tensor] = None,
+        weights: types.Tensor | None = None,
     ) -> types.Tensor:
         """Apply embedding and reduction.
 
@@ -276,7 +276,7 @@ class EmbedReduce(keras.layers.Embedding):
     def compute_output_shape(
         self,
         input_shape: types.Shape,
-        weights_shape: Optional[types.Shape] = None,
+        weights_shape: types.Shape | None = None,
     ) -> types.Shape:
         del weights_shape
 
@@ -290,7 +290,7 @@ class EmbedReduce(keras.layers.Embedding):
     def compute_output_spec(
         self,
         inputs: keras.KerasTensor,
-        weights: Optional[keras.KerasTensor] = None,
+        weights: keras.KerasTensor | None = None,
     ) -> keras.KerasTensor:
         del weights
 

--- a/keras_rs/src/layers/embedding/jax/config_conversion.py
+++ b/keras_rs/src/layers/embedding/jax/config_conversion.py
@@ -3,7 +3,7 @@
 import inspect
 import math
 import random as python_random
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
@@ -24,7 +24,7 @@ class WrappedKerasInitializer(jax.nn.initializers.Initializer):
             initializer = keras.initializers.get(initializer)
         self.initializer = initializer
 
-    def key(self) -> Union[jax.Array, None]:
+    def key(self) -> jax.Array | None:
         """Extract a key from the underlying keras initializer."""
         # All built-in keras initializers have a `seed` attribute.
         # Extract this and turn it into a key for use with JAX.
@@ -71,7 +71,7 @@ class WrappedJaxInitializer(keras.initializers.Initializer):
     def __init__(
         self,
         initializer: jax.nn.initializers.Initializer,
-        seed: Optional[Union[int, keras.random.SeedGenerator]] = None,
+        seed: int | keras.random.SeedGenerator | None = None,
     ):
         self.initializer = initializer
         if seed is None:
@@ -94,7 +94,7 @@ class WrappedJaxInitializer(keras.initializers.Initializer):
     def __call__(
         self,
         shape: types.Shape,
-        dtype: Optional[types.DType] = None,
+        dtype: types.DType | None = None,
         **kwargs: Any,
     ) -> jax.Array:
         del kwargs  # Unused.
@@ -102,7 +102,7 @@ class WrappedJaxInitializer(keras.initializers.Initializer):
 
 
 def keras_to_jax_initializer(
-    initializer: Union[str, keras.initializers.Initializer],
+    initializer: str | keras.initializers.Initializer,
 ) -> jax.nn.initializers.Initializer:
     """Converts a Keras initializer to a JAX initializer.
 
@@ -134,8 +134,8 @@ def jax_to_keras_initializer(
 
 
 def keras_to_jte_learning_rate(
-    learning_rate: Union[keras.Variable, float, Callable[..., float]],
-) -> Union[float, Callable[..., float]]:
+    learning_rate: keras.Variable | float | Callable[..., float],
+) -> float | Callable[..., float]:
     """Converts a Keras learning rate to a JAX TPU Embedding learning rate.
 
     Args:
@@ -177,8 +177,8 @@ def keras_to_jte_learning_rate(
 
 
 def jte_to_keras_learning_rate(
-    learning_rate: Union[float, Callable[..., float]],
-) -> Union[float, Callable[..., float]]:
+    learning_rate: float | Callable[..., float],
+) -> float | Callable[..., float]:
     """Converts a JAX TPU Embedding learning rate to a Keras learning rate.
 
     Args:
@@ -209,7 +209,7 @@ def jte_to_keras_learning_rate(
 
 
 def keras_to_jte_optimizer(
-    optimizer: Union[keras.optimizers.Optimizer, str],
+    optimizer: keras.optimizers.Optimizer | str,
 ) -> embedding_spec.OptimizerSpec:
     """Converts a Keras optimizer to a JAX TPU Embedding optimizer.
 

--- a/keras_rs/src/layers/embedding/jax/config_conversion_test.py
+++ b/keras_rs/src/layers/embedding/jax/config_conversion_test.py
@@ -1,6 +1,6 @@
 import inspect
 import typing
-from typing import Callable, Union
+from typing import Callable
 
 import jax
 import keras
@@ -21,12 +21,16 @@ from keras_rs.src.layers.embedding.jax import config_conversion
 class ConfigConversionTest(parameterized.TestCase):
     def assert_initializers_equal(
         self,
-        initializer_a: Union[
-            str, keras.initializers.Initializer, jax.nn.initializers.Initializer
-        ],
-        initializer_b: Union[
-            str, keras.initializers.Initializer, jax.nn.initializers.Initializer
-        ],
+        initializer_a: (
+            str
+            | keras.initializers.Initializer
+            | jax.nn.initializers.Initializer
+        ),
+        initializer_b: (
+            str
+            | keras.initializers.Initializer
+            | jax.nn.initializers.Initializer
+        ),
     ):
         """Compare two initializers to ensure they are equivalent."""
         if isinstance(initializer_a, str):
@@ -62,12 +66,12 @@ class ConfigConversionTest(parameterized.TestCase):
 
     def assert_optimizers_equal(
         self,
-        optimizer_a: Union[
-            str, keras.optimizers.Optimizer, embedding_spec.OptimizerSpec
-        ],
-        optimizer_b: Union[
-            str, keras.optimizers.Optimizer, embedding_spec.OptimizerSpec
-        ],
+        optimizer_a: (
+            str | keras.optimizers.Optimizer | embedding_spec.OptimizerSpec
+        ),
+        optimizer_b: (
+            str | keras.optimizers.Optimizer | embedding_spec.OptimizerSpec
+        ),
     ):
         """Compare two optimizers to ensure they are equivalent."""
         if isinstance(optimizer_a, str):
@@ -100,8 +104,8 @@ class ConfigConversionTest(parameterized.TestCase):
 
     def assert_table_configs_equal(
         self,
-        table_a: Union[config.TableConfig, embedding_spec.TableSpec],
-        table_b: Union[config.TableConfig, embedding_spec.TableSpec],
+        table_a: config.TableConfig | embedding_spec.TableSpec,
+        table_b: config.TableConfig | embedding_spec.TableSpec,
     ):
         """Compare two table configs to ensure they are equivalent."""
         self.assertEqual(table_a.name, table_b.name)
@@ -119,7 +123,7 @@ class ConfigConversionTest(parameterized.TestCase):
         self.assert_optimizers_equal(table_a.optimizer, table_b.optimizer)
 
     def get_learning_rate(
-        self, learning_rate: Union[float, Callable[..., float]], step: int
+        self, learning_rate: float | Callable[..., float], step: int
     ):
         """Gets the learning rate at the provided iteration step.
 
@@ -168,7 +172,7 @@ class ConfigConversionTest(parameterized.TestCase):
         ),
     )
     def test_learning_rate_conversion(
-        self, learning_rate: Union[float, Callable[..., float]]
+        self, learning_rate: float | Callable[..., float]
     ):
         jte_learning_rate = config_conversion.keras_to_jte_learning_rate(
             learning_rate
@@ -199,7 +203,7 @@ class ConfigConversionTest(parameterized.TestCase):
         ("zeros", "zeros"),
     )
     def test_initializer_conversion(
-        self, initializer: Union[keras.initializers.Initializer, str]
+        self, initializer: keras.initializers.Initializer | str
     ):
         jte_initializer = typing.cast(
             config_conversion.WrappedKerasInitializer,
@@ -239,7 +243,7 @@ class ConfigConversionTest(parameterized.TestCase):
     )
     def test_optimizer_conversion(
         self,
-        lazy_optimizer: Callable[..., Union[keras.optimizers.Optimizer, str]],
+        lazy_optimizer: Callable[..., keras.optimizers.Optimizer | str],
     ):
         optimizer = lazy_optimizer()
         jte_optimizer = config_conversion.keras_to_jte_optimizer(optimizer)

--- a/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Tuple, Union
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -70,7 +70,7 @@ class ShardedInitializerTest(parameterized.TestCase):
         ],
     )
     def test_wrap_and_call(
-        self, initializer: Union[keras.initializers.Initializer, str]
+        self, initializer: keras.initializers.Initializer | str
     ):
         device_count = jax.device_count()
         layout = _create_sparsecore_layout()
@@ -275,7 +275,7 @@ class StackedTableInitializerTest(parameterized.TestCase):
             stacked_table_spec.stack_embedding_dim,
         )
 
-        def my_initializer(shape: Tuple[int, int], dtype: Any):
+        def my_initializer(shape: tuple[int, int], dtype: Any):
             layout = _create_sparsecore_layout()
             initializer = jax_distributed_embedding.StackedTableInitializer(
                 table_specs, num_table_shards, layout
@@ -310,7 +310,7 @@ class DistributedEmbeddingLayerTest(parameterized.TestCase):
         self,
         ragged: bool,
         combiner: str,
-        table_stacking: Union[str, list[str], list[list[str]]],
+        table_stacking: str | list[str] | list[list[str]],
         jit: bool,
     ):
         if ragged and not test_utils.has_sparsecores():
@@ -381,7 +381,7 @@ class DistributedEmbeddingLayerTest(parameterized.TestCase):
     def test_fit(
         self,
         ragged: bool,
-        table_stacking: Union[str, list[str], list[list[str]]],
+        table_stacking: str | list[str] | list[list[str]],
     ):
         if ragged and not test_utils.has_sparsecores():
             self.skipTest(

--- a/keras_rs/src/layers/embedding/jax/embedding_lookup.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_lookup.py
@@ -4,7 +4,7 @@ Implementation details for use in JAX models.
 """
 
 import functools
-from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Mapping, TypeAlias
 
 import jax
 import numpy as np
@@ -14,14 +14,13 @@ from jax_tpu_embedding.sparsecore.lib.nn import embedding_spec
 from jax_tpu_embedding.sparsecore.utils import utils as jte_utils
 
 from keras_rs.src.layers.embedding.jax import embedding_utils
+from keras_rs.src.types import Nested
 
 ShardedCooMatrix = embedding_utils.ShardedCooMatrix
 shard_map = jax.experimental.shard_map.shard_map  # type: ignore[attr-defined]
 
-T = TypeVar("T")
-Nested = Union[T, Sequence[T], Mapping[str, T]]
-ArrayLike = Union[jax.Array, np.ndarray[Any, Any]]
-JaxLayout = Union[jax.sharding.NamedSharding, layout.Layout]
+ArrayLike: TypeAlias = jax.Array | np.ndarray[Any, Any]
+JaxLayout: TypeAlias = jax.sharding.NamedSharding | layout.Layout
 
 
 class EmbeddingLookupConfiguration:
@@ -38,14 +37,14 @@ class EmbeddingLookupConfiguration:
     def __init__(
         self,
         feature_specs: embedding.Nested[embedding_spec.FeatureSpec],
-        mesh: Optional[jax.sharding.Mesh] = None,
+        mesh: jax.sharding.Mesh | None = None,
         table_sharding_strategy: str = "MOD",
-        num_sc_per_device: Optional[int] = None,
+        num_sc_per_device: int | None = None,
         sharding_axis: str = "sparsecore_sharding",
-        samples_partition: Optional[jax.sharding.PartitionSpec] = None,
-        samples_layout: Optional[JaxLayout] = None,
-        table_partition: Optional[jax.sharding.PartitionSpec] = None,
-        table_layout: Optional[JaxLayout] = None,
+        samples_partition: jax.sharding.PartitionSpec | None = None,
+        samples_layout: JaxLayout | None = None,
+        table_partition: jax.sharding.PartitionSpec | None = None,
+        table_layout: JaxLayout | None = None,
     ):
         self.mesh = mesh or jax.sharding.Mesh(jax.devices(), sharding_axis)
         self.feature_specs = feature_specs
@@ -79,7 +78,7 @@ def embedding_lookup(
     config: EmbeddingLookupConfiguration,
     lookups: Mapping[str, ShardedCooMatrix],
     tables: Nested[jax.Array],
-    step: Optional[jax.Array] = None,
+    step: jax.Array | None = None,
 ) -> Nested[jax.Array]:
     """Embedding lookup function with custom gradient.
 
@@ -138,10 +137,10 @@ def embedding_lookup_fwd(
     config: EmbeddingLookupConfiguration,
     lookups: Mapping[str, ShardedCooMatrix],
     table: Nested[jax.Array],
-    step: Optional[jax.Array] = None,
-) -> Tuple[
+    step: jax.Array | None = None,
+) -> tuple[
     Nested[jax.Array],
-    Tuple[Nested[ShardedCooMatrix], Nested[jax.Array], Optional[jax.Array]],
+    tuple[Nested[ShardedCooMatrix], Nested[jax.Array], jax.Array | None],
 ]:
     """Forward pass for embedding lookup."""
     return embedding_lookup(config, lookups, table, step), (
@@ -153,13 +152,13 @@ def embedding_lookup_fwd(
 
 def embedding_lookup_bwd(
     config: EmbeddingLookupConfiguration,
-    res: Tuple[
+    res: tuple[
         Mapping[str, ShardedCooMatrix],  # Lookups.
         Mapping[str, Nested[jax.Array]],  # Tables.
-        Optional[jax.Array],  # Step.
+        jax.Array | None,  # Step.
     ],
     gradients: Nested[jax.Array],
-) -> Tuple[None, Nested[jax.Array], Optional[jax.Array]]:
+) -> tuple[None, Nested[jax.Array], jax.Array | None]:
     """Backward pass for embedding lookup.
 
     Args:
@@ -199,7 +198,7 @@ def embedding_lookup_bwd(
         gradients: Nested[jax.Array],
         sparse_input: embedding.SparseDenseMatmulInput,
         tables: Mapping[str, embedding.EmbeddingVariables],
-        step: Optional[jax.Array],
+        step: jax.Array | None,
     ) -> Mapping[str, embedding.EmbeddingVariables]:
         output: Mapping[str, embedding.EmbeddingVariables] = (
             embedding.tpu_sparse_dense_matmul_grad(

--- a/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
@@ -1,6 +1,6 @@
 import functools
 import typing
-from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, TypeAlias
 
 import jax
 import jax.numpy as jnp
@@ -17,12 +17,11 @@ from jax_tpu_embedding.sparsecore.utils import utils as jte_utils
 from keras_rs.src.layers.embedding.jax import embedding_lookup
 from keras_rs.src.layers.embedding.jax import embedding_utils
 from keras_rs.src.layers.embedding.jax import test_utils
+from keras_rs.src.types import Nested
 
 shard_map = jax.experimental.shard_map.shard_map
 
-Shape = Tuple[int, ...]
-T = TypeVar("T")
-Nested = Union[T, Sequence[T], Mapping[str, T]]
+Shape: TypeAlias = tuple[int, ...]
 
 
 class TableInfo:
@@ -65,9 +64,9 @@ class EmbeddingLookupTest(parameterized.TestCase):
 
     def _create_test_tables(
         self,
-        table_info: Optional[Nested[TableInfo]],
-        optimizer: Optional[embedding_spec.OptimizerSpec] = None,
-        initializer: Optional[jax.nn.initializers.Initializer] = None,
+        table_info: Nested[TableInfo] | None,
+        optimizer: embedding_spec.OptimizerSpec | None = None,
+        initializer: jax.nn.initializers.Initializer | None = None,
     ) -> dict[str, embedding_spec.TableSpec]:
         return keras.tree.map_structure(
             lambda info: test_utils.create_table_spec(
@@ -100,8 +99,8 @@ class EmbeddingLookupTest(parameterized.TestCase):
 
     def _create_table_and_feature_specs(
         self,
-        table_initializer: Optional[jax.nn.initializers.Initializer] = None,
-        optimizer: Optional[embedding_spec.OptimizerSpec] = None,
+        table_initializer: jax.nn.initializers.Initializer | None = None,
+        optimizer: embedding_spec.OptimizerSpec | None = None,
     ):
         table_specs = self._create_test_tables(
             {
@@ -480,7 +479,7 @@ class EmbeddingLookupTest(parameterized.TestCase):
             )
         )
         sharded_table_and_slot_variables = typing.cast(
-            dict[str, Tuple[jax.Array, ...]], sharded_table_and_slot_variables
+            dict[str, tuple[jax.Array, ...]], sharded_table_and_slot_variables
         )
 
         # Shard samples for lookup query.

--- a/keras_rs/src/layers/embedding/jax/embedding_utils.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_utils.py
@@ -3,16 +3,7 @@
 import collections
 import dataclasses
 import typing
-from typing import (
-    Any,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Mapping, NamedTuple, Sequence, TypeAlias, TypeVar
 
 import jax
 import numpy as np
@@ -22,13 +13,13 @@ from jax_tpu_embedding.sparsecore.lib.nn.embedding_spec import FeatureSpec
 from jax_tpu_embedding.sparsecore.lib.nn.embedding_spec import StackedTableSpec
 from jax_tpu_embedding.sparsecore.lib.nn.embedding_spec import TableSpec
 
+from keras_rs.src.types import Nested
+
 T = TypeVar("T")
-U = TypeVar("U")
-Nested = Union[T, Sequence[T], Mapping[str, T]]
 
 # Any to support tf.Ragged without needing an explicit TF dependency.
-ArrayLike = Union[jax.Array, np.ndarray, Any]  # type: ignore
-Shape = Tuple[int, ...]
+ArrayLike: TypeAlias = jax.Array | np.ndarray | Any  # type: ignore
+Shape: TypeAlias = tuple[int, ...]
 
 
 class FeatureSamples(NamedTuple):
@@ -165,7 +156,7 @@ def stack_and_shard_tables(
     # Gather stacked table information.
     stacked_table_map: dict[
         str,
-        Tuple[StackedTableSpec, list[TableSpec]],
+        tuple[StackedTableSpec, list[TableSpec]],
     ] = {}
 
     def collect_stacked_tables(table_spec: TableSpec) -> None:
@@ -396,7 +387,7 @@ def update_stacked_table_specs(
 
 
 def convert_to_numpy(
-    ragged_or_dense: Union[np.ndarray[Any, Any], Sequence[Sequence[Any]], Any],
+    ragged_or_dense: np.ndarray[Any, Any] | Sequence[Sequence[Any]] | Any,
     dtype: Any,
 ) -> np.ndarray[Any, Any]:
     """Converts a ragged or dense list of inputs to a ragged/dense numpy array.
@@ -480,12 +471,9 @@ def ones_like(
 
 def create_feature_samples(
     feature_structure: Nested[T],
-    feature_ids: Nested[
-        Union[ArrayLike, Sequence[int], Sequence[Sequence[int]]]
-    ],
-    feature_weights: Optional[
-        Nested[Union[ArrayLike, Sequence[float], Sequence[Sequence[float]]]]
-    ],
+    feature_ids: Nested[ArrayLike | Sequence[int] | Sequence[Sequence[int]]],
+    feature_weights: None
+    | (Nested[ArrayLike | Sequence[float] | Sequence[Sequence[float]]]),
 ) -> Nested[FeatureSamples]:
     """Constructs a collection of sample tuples from provided IDs and weights.
 
@@ -545,8 +533,8 @@ def stack_and_shard_samples(
     local_device_count: int,
     global_device_count: int,
     num_sc_per_device: int,
-    static_buffer_size: Optional[Union[int, Mapping[str, int]]] = None,
-) -> Tuple[dict[str, ShardedCooMatrix], embedding.SparseDenseMatmulInputStats]:
+    static_buffer_size: int | Mapping[str, int] | None = None,
+) -> tuple[dict[str, ShardedCooMatrix], embedding.SparseDenseMatmulInputStats]:
     """Prepares input samples for use in embedding lookups.
 
     Args:

--- a/keras_rs/src/layers/embedding/jax/test_utils.py
+++ b/keras_rs/src/layers/embedding/jax/test_utils.py
@@ -1,7 +1,7 @@
 """JAX-specific test utilities for embedding layers."""
 
 import typing
-from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Mapping, TypeAlias, Union
 
 import jax
 import keras
@@ -13,11 +13,10 @@ from jax_tpu_embedding.sparsecore.lib.nn.embedding_spec import TableSpec
 
 from keras_rs.src.layers.embedding.jax import embedding_utils
 from keras_rs.src.layers.embedding.jax.embedding_utils import FeatureSamples
+from keras_rs.src.types import Nested
 
-T = TypeVar("T")
-Nested = Union[T, Sequence[T], Mapping[str, T]]
-ArrayLike = Union[jax.Array, np.ndarray[Any, Any]]
-Shape = Tuple[int, ...]
+ArrayLike: TypeAlias = Union[jax.Array, np.ndarray[Any, Any]]
+Shape: TypeAlias = tuple[int, ...]
 
 
 def has_sparsecores() -> bool:
@@ -37,8 +36,8 @@ def create_table_spec(
     embedding_dim: int,
     max_ids_per_partition: int = 0,
     max_unique_ids_per_partition: int = 0,
-    initializer: Optional[jax.nn.initializers.Initializer] = None,
-    optimizer: Optional[embedding_spec.OptimizerSpec] = None,
+    initializer: jax.nn.initializers.Initializer | None = None,
+    optimizer: embedding_spec.OptimizerSpec | None = None,
     combiner: str = "sum",
 ) -> TableSpec:
     """Creates a TableSpec with appropriate defaults."""
@@ -107,7 +106,7 @@ def _get_stacked_table_spec(
 
 def create_tables(
     table_specs: Nested[TableSpec],
-    keys: Optional[Nested[ArrayLike]] = None,
+    keys: Nested[ArrayLike] | None = None,
 ) -> Nested[ArrayLike]:
     """Creates and initializes embedding tables.
 
@@ -142,7 +141,7 @@ def create_tables(
 
 def create_table_and_slot_variables(
     table_specs: Nested[TableSpec],
-    keys: Optional[Nested[ArrayLike]] = None,
+    keys: Nested[ArrayLike] | None = None,
 ) -> Nested[ArrayLike]:
     """Creates and initializes embedding tables and slot variables.
 
@@ -165,7 +164,7 @@ def create_table_and_slot_variables(
     def _create_table_and_slot_variables(
         table_spec: TableSpec,
         key: ArrayLike,
-    ) -> Tuple[jax.Array, Tuple[jax.Array, ...]]:
+    ) -> tuple[jax.Array, tuple[jax.Array, ...]]:
         slot_initializers = table_spec.optimizer.slot_variables_initializers()
         num_slot_variables = len(keras.tree.flatten(slot_initializers))
         slot_keys = jnp.unstack(jax.random.split(key, num_slot_variables))
@@ -194,10 +193,9 @@ def generate_feature_samples(
     feature_specs: Nested[FeatureSpec],
     max_samples: Nested[int] = 16,
     ragged: bool = True,
-    keys: Optional[Nested[int]] = None,
-    sample_weight_initializer: Optional[
-        Nested[jax.nn.initializers.Initializer]
-    ] = None,
+    keys: Nested[int] | None = None,
+    sample_weight_initializer: None
+    | (Nested[jax.nn.initializers.Initializer]) = None,
 ) -> Nested[FeatureSamples]:
     """Generates random feature samples for embedding lookup testing.
 
@@ -419,7 +417,7 @@ def compute_expected_lookup_grad(
     feature_samples: Nested[FeatureSamples],
     activation_gradients: Nested[jax.Array],
     table_specs: Nested[TableSpec],
-) -> Tuple[None, Nested[jax.Array]]:
+) -> tuple[None, Nested[jax.Array]]:
     """Computes the expected gradient of an embedding lookup.
 
     Args:
@@ -471,10 +469,10 @@ def compute_expected_lookup_grad(
 def _update_table_and_slot_variables(
     table_spec: TableSpec,
     grad: jax.Array,
-    table_and_slot_variables: Tuple[jax.Array, Tuple[jax.Array, ...]],
-) -> Tuple[
+    table_and_slot_variables: tuple[jax.Array, tuple[jax.Array, ...]],
+) -> tuple[
     jax.Array,
-    Union[embedding_spec.SGDSlotVariables, embedding_spec.AdagradSlotVariables],
+    embedding_spec.SGDSlotVariables | embedding_spec.AdagradSlotVariables,
 ]:
     """Updates a table and its slot variables based on the gradient."""
     table = table_and_slot_variables[0]

--- a/keras_rs/src/layers/embedding/tensorflow/config_conversion.py
+++ b/keras_rs/src/layers/embedding/tensorflow/config_conversion.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Sequence, TypeAlias
 
 import keras
 import tensorflow as tf
@@ -11,7 +11,7 @@ FeatureConfig = distributed_embedding_config.FeatureConfig
 TableConfig = distributed_embedding_config.TableConfig
 
 # Placeholder of tf.tpu.experimental.embedding._Optimizer which is not exposed.
-TfTpuOptimizer = Any
+TfTpuOptimizer: TypeAlias = Any
 
 
 OptimizerMapping = collections.namedtuple(
@@ -55,7 +55,7 @@ OPTIMIZER_MAPPINGS = {
 
 def translate_keras_rs_configuration(
     feature_configs: types.Nested[FeatureConfig],
-    table_stacking: Union[str, Sequence[str], Sequence[Sequence[str]]],
+    table_stacking: str | Sequence[str] | Sequence[Sequence[str]],
 ) -> tuple[
     types.Nested[tf.tpu.experimental.embedding.FeatureConfig],
     tf.tpu.experimental.embedding.SparseCoreEmbeddingConfig,
@@ -226,7 +226,7 @@ def translate_keras_optimizer(
 
 
 def translate_optimizer(
-    optimizer: Optional[Union[str, keras.optimizers.Optimizer, TfTpuOptimizer]],
+    optimizer: str | keras.optimizers.Optimizer | TfTpuOptimizer | None,
 ) -> TfTpuOptimizer:
     """Translates a Keras optimizer into a TensorFlow TPU `_Optimizer`.
 

--- a/keras_rs/src/layers/embedding/tensorflow/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/tensorflow/distributed_embedding.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Sequence, TypeAlias
 
 import keras
 import tensorflow as tf
@@ -13,7 +13,7 @@ FeatureConfig = distributed_embedding_config.FeatureConfig
 TableConfig = distributed_embedding_config.TableConfig
 
 # Placeholder of tf.tpu.experimental.embedding._Optimizer which is not exposed.
-TfTpuOptimizer = Any
+TfTpuOptimizer: TypeAlias = Any
 
 
 GRADIENT_TRAP_DUMMY_NAME = "_gradient_trap_dummy"
@@ -29,12 +29,12 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
     def __init__(
         self,
         feature_configs: types.Nested[
-            Union[FeatureConfig, tf.tpu.experimental.embedding.FeatureConfig]
+            FeatureConfig | tf.tpu.experimental.embedding.FeatureConfig
         ],
         *,
-        table_stacking: Union[
-            str, Sequence[str], Sequence[Sequence[str]]
-        ] = "auto",
+        table_stacking: (
+            str | Sequence[str] | Sequence[Sequence[str]]
+        ) = "auto",
         **kwargs: Any,
     ) -> None:
         # Intercept arguments that are supported only on TensorFlow.
@@ -77,9 +77,9 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
         self,
         feature_configs: dict[
             str,
-            Union[FeatureConfig, tf.tpu.experimental.embedding.FeatureConfig],
+            FeatureConfig | tf.tpu.experimental.embedding.FeatureConfig,
         ],
-        table_stacking: Union[str, Sequence[str], Sequence[Sequence[str]]],
+        table_stacking: str | Sequence[str] | Sequence[Sequence[str]],
     ) -> None:
         self._table_stacking = table_stacking
 
@@ -246,7 +246,7 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
     def _sparsecore_call(
         self,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]] = None,
+        weights: dict[str, types.Tensor] | None = None,
         training: bool = False,
     ) -> dict[str, types.Tensor]:
         del training  # Unused.
@@ -321,7 +321,7 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
         self,
         tpu_embedding: tf.tpu.experimental.embedding.TPUEmbedding,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]] = None,
+        weights: dict[str, types.Tensor] | None = None,
     ) -> dict[str, types.Tensor]:
         # Each call to this function increments the _v1_call_id by 1, this
         # allows us to tag each of the main embedding ops with this call id so
@@ -372,7 +372,7 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
         self,
         tpu_embedding: tf.tpu.experimental.embedding.TPUEmbeddingV2,
         inputs: dict[str, types.Tensor],
-        weights: Optional[dict[str, types.Tensor]] = None,
+        weights: dict[str, types.Tensor] | None = None,
     ) -> dict[str, types.Tensor]:
         @tf.custom_gradient  # type: ignore
         def gradient_trap(

--- a/keras_rs/src/layers/embedding/test_utils.py
+++ b/keras_rs/src/layers/embedding/test_utils.py
@@ -1,31 +1,24 @@
 """Useful utilities for tests."""
 
 import typing
-from typing import (
-    Any,
-    Callable,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Mapping, Sequence, TypeAlias
 
 import keras
 import numpy as np
 
-from keras_rs.src.layers.embedding import distributed_embedding_config as config
+from keras_rs.src.layers.embedding.distributed_embedding_config import (
+    FeatureConfig,
+)
+from keras_rs.src.layers.embedding.distributed_embedding_config import (
+    TableConfig,
+)
 from keras_rs.src.types import Nested
 
-T = TypeVar("T")
-RandomSeed = Union[int, keras.random.SeedGenerator]
-FeatureConfig = config.FeatureConfig
-TableConfig = config.TableConfig
-AnyNdArray = np.ndarray[Any, Any]
+RandomSeed: TypeAlias = int | keras.random.SeedGenerator
+AnyNdArray: TypeAlias = np.ndarray[Any, Any]
 
 
-def _make_rng(seed: Optional[RandomSeed]) -> keras.random.SeedGenerator:
+def _make_rng(seed: RandomSeed | None) -> keras.random.SeedGenerator:
     """Make a seed generator for use in generating random configurations."""
     if seed is None:
         seed = keras.random.SeedGenerator()
@@ -38,13 +31,13 @@ def create_random_table_configs(
     count: int = 3,
     max_vocabulary_size: int = 1024,
     max_embedding_dim: int = 128,
-    initializer: Optional[Union[str, keras.initializers.Initializer]] = None,
-    optimizer: Union[str, keras.optimizers.Optimizer] = "sgd",
+    initializer: str | keras.initializers.Initializer | None = None,
+    optimizer: str | keras.optimizers.Optimizer = "sgd",
     combiner: str = "mean",
     placement: str = "auto",
     max_ids_per_partition: int = 256,
     max_unique_ids_per_partition: int = 256,
-    seed: Optional[RandomSeed] = None,
+    seed: RandomSeed | None = None,
     name_prefix: str = "table",
 ) -> list[TableConfig]:
     """Creates a list of random TableConfigs for use in tests.
@@ -95,10 +88,10 @@ def create_random_table_configs(
 
 
 def create_random_feature_configs(
-    table_configs: Optional[Sequence[TableConfig]] = None,
+    table_configs: Sequence[TableConfig] | None = None,
     max_features_per_table: int = 3,
     batch_size: int = 16,
-    seed: Optional[RandomSeed] = None,
+    seed: RandomSeed | None = None,
     name_prefix: str = "feature",
 ) -> list[FeatureConfig]:
     """Creates a list of random FeatureConfigs for tests.
@@ -150,8 +143,8 @@ def create_random_samples(
     feature_configs: Nested[FeatureConfig],
     ragged: bool = True,
     max_ids_per_sample: int = 20,
-    seed: Optional[RandomSeed] = None,
-) -> Tuple[Nested[AnyNdArray], Nested[AnyNdArray]]:
+    seed: RandomSeed | None = None,
+) -> tuple[Nested[AnyNdArray], Nested[AnyNdArray]]:
     """Creates random feature samples.
 
     Args:
@@ -169,7 +162,7 @@ def create_random_samples(
 
     def _generate_samples(
         feature_config: FeatureConfig,
-    ) -> Tuple[AnyNdArray, AnyNdArray]:
+    ) -> tuple[AnyNdArray, AnyNdArray]:
         batch_size = typing.cast(int, feature_config.input_shape[0])
         vocabulary_size = feature_config.table.vocabulary_size
         counts = keras.random.randint(
@@ -337,7 +330,7 @@ class RandomInputSampleDataset(keras.utils.PyDataset):
         max_ids_per_sample: int = 20,
         num_batches: int = 1000,
         seed: int = 0,
-        preprocessor: Optional[Callable[..., Any]] = None,
+        preprocessor: Callable[..., Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -354,7 +347,7 @@ class RandomInputSampleDataset(keras.utils.PyDataset):
     def __len__(self) -> int:
         return self._num_batches
 
-    def __getitem__(self, idx: int) -> Tuple[Any, Any]:
+    def __getitem__(self, idx: int) -> tuple[Any, Any]:
         sample_ids, sample_weights = create_random_samples(
             self._feature_configs,
             self._ragged,

--- a/keras_rs/src/layers/feature_interaction/feature_cross.py
+++ b/keras_rs/src/layers/feature_interaction/feature_cross.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Text, Union
+from typing import Any
 
 import keras
 from keras import ops
@@ -92,20 +92,18 @@ class FeatureCross(keras.layers.Layer):
 
     def __init__(
         self,
-        projection_dim: Optional[int] = None,
-        diag_scale: Optional[float] = 0.0,
+        projection_dim: int | None = None,
+        diag_scale: float | None = 0.0,
         use_bias: bool = True,
-        pre_activation: Optional[Union[str, keras.layers.Activation]] = None,
-        kernel_initializer: Union[
-            Text, keras.initializers.Initializer
-        ] = "glorot_uniform",
-        bias_initializer: Union[Text, keras.initializers.Initializer] = "zeros",
-        kernel_regularizer: Union[
-            Text, None, keras.regularizers.Regularizer
-        ] = None,
-        bias_regularizer: Union[
-            Text, None, keras.regularizers.Regularizer
-        ] = None,
+        pre_activation: str | keras.layers.Activation | None = None,
+        kernel_initializer: (
+            str | keras.initializers.Initializer
+        ) = "glorot_uniform",
+        bias_initializer: str | keras.initializers.Initializer = "zeros",
+        kernel_regularizer: (
+            str | None | keras.regularizers.Regularizer
+        ) = None,
+        bias_regularizer: (str | None | keras.regularizers.Regularizer) = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -155,7 +153,7 @@ class FeatureCross(keras.layers.Layer):
         self.built = True
 
     def call(
-        self, x0: types.Tensor, x: Optional[types.Tensor] = None
+        self, x0: types.Tensor, x: types.Tensor | None = None
     ) -> types.Tensor:
         """Forward pass of the cross layer.
 

--- a/keras_rs/src/layers/retrieval/brute_force_retrieval.py
+++ b/keras_rs/src/layers/retrieval/brute_force_retrieval.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 import keras
 
@@ -55,8 +55,8 @@ class BruteForceRetrieval(Retrieval):
 
     def __init__(
         self,
-        candidate_embeddings: Optional[types.Tensor] = None,
-        candidate_ids: Optional[types.Tensor] = None,
+        candidate_embeddings: types.Tensor | None = None,
+        candidate_ids: types.Tensor | None = None,
         k: int = 10,
         return_scores: bool = True,
         **kwargs: Any,
@@ -81,7 +81,7 @@ class BruteForceRetrieval(Retrieval):
     def update_candidates(
         self,
         candidate_embeddings: types.Tensor,
-        candidate_ids: Optional[types.Tensor] = None,
+        candidate_ids: types.Tensor | None = None,
     ) -> None:
         """Update the set of candidates and optionally their candidate IDs.
 
@@ -125,7 +125,7 @@ class BruteForceRetrieval(Retrieval):
 
     def call(
         self, inputs: types.Tensor
-    ) -> Union[types.Tensor, tuple[types.Tensor, types.Tensor]]:
+    ) -> types.Tensor | tuple[types.Tensor, types.Tensor]:
         """Returns the top candidates for the query passed as input.
 
         Args:

--- a/keras_rs/src/layers/retrieval/retrieval.py
+++ b/keras_rs/src/layers/retrieval/retrieval.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Optional, Union
+from typing import Any
 
 import keras
 
@@ -35,7 +35,7 @@ class Retrieval(keras.layers.Layer, abc.ABC):
     def _validate_candidate_embeddings_and_ids(
         self,
         candidate_embeddings: types.Tensor,
-        candidate_ids: Optional[types.Tensor] = None,
+        candidate_ids: types.Tensor | None = None,
     ) -> None:
         """Validates inputs to `update_candidates()`."""
 
@@ -71,7 +71,7 @@ class Retrieval(keras.layers.Layer, abc.ABC):
     def update_candidates(
         self,
         candidate_embeddings: types.Tensor,
-        candidate_ids: Optional[types.Tensor] = None,
+        candidate_ids: types.Tensor | None = None,
     ) -> None:
         """Update the set of candidates and optionally their candidate IDs.
 
@@ -85,7 +85,7 @@ class Retrieval(keras.layers.Layer, abc.ABC):
     @abc.abstractmethod
     def call(
         self, inputs: types.Tensor
-    ) -> Union[types.Tensor, tuple[types.Tensor, types.Tensor]]:
+    ) -> types.Tensor | tuple[types.Tensor, types.Tensor]:
         """Returns the top candidates for the query passed as input.
 
         Args:

--- a/keras_rs/src/losses/pairwise_loss.py
+++ b/keras_rs/src/losses/pairwise_loss.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Optional
+from typing import Any
 
 import keras
 from keras import ops
@@ -43,7 +43,7 @@ class PairwiseLoss(keras.losses.Loss, abc.ABC):
         self,
         labels: types.Tensor,
         logits: types.Tensor,
-        mask: Optional[types.Tensor] = None,
+        mask: types.Tensor | None = None,
     ) -> tuple[types.Tensor, types.Tensor]:
         # Mask all values less than 0 (since less than 0 implies invalid
         # labels).

--- a/keras_rs/src/losses/pairwise_mean_squared_error.py
+++ b/keras_rs/src/losses/pairwise_mean_squared_error.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from keras import ops
 
 from keras_rs.src import types
@@ -20,7 +18,7 @@ class PairwiseMeanSquaredError(PairwiseLoss):
         self,
         labels: types.Tensor,
         logits: types.Tensor,
-        mask: Optional[types.Tensor] = None,
+        mask: types.Tensor | None = None,
     ) -> tuple[types.Tensor, types.Tensor]:
         # Override `PairwiseLoss.compute_unreduced_loss` since pairwise weights
         # for MSE are computed differently.

--- a/keras_rs/src/metrics/dcg.py
+++ b/keras_rs/src/metrics/dcg.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from keras import ops
 from keras.saving import deserialize_keras_object
@@ -25,7 +25,7 @@ from keras_rs.src.utils.doc_string_utils import format_docstring
 class DCG(RankingMetric):
     def __init__(
         self,
-        k: Optional[int] = None,
+        k: int | None = None,
         gain_fn: Callable[[types.Tensor], types.Tensor] = default_gain_fn,
         rank_discount_fn: Callable[
             [types.Tensor], types.Tensor

--- a/keras_rs/src/metrics/ndcg.py
+++ b/keras_rs/src/metrics/ndcg.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from keras import ops
 from keras.saving import deserialize_keras_object
@@ -25,7 +25,7 @@ from keras_rs.src.utils.doc_string_utils import format_docstring
 class NDCG(RankingMetric):
     def __init__(
         self,
-        k: Optional[int] = None,
+        k: int | None = None,
         gain_fn: Callable[[types.Tensor], types.Tensor] = default_gain_fn,
         rank_discount_fn: Callable[
             [types.Tensor], types.Tensor

--- a/keras_rs/src/metrics/ranking_metric.py
+++ b/keras_rs/src/metrics/ranking_metric.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Optional, Union
+from typing import Any
 
 import keras
 from keras import ops
@@ -39,9 +39,9 @@ class RankingMetric(keras.metrics.Mean, abc.ABC):
 
     def __init__(
         self,
-        k: Optional[int] = None,
+        k: int | None = None,
         shuffle_ties: bool = True,
-        seed: Optional[Union[int, keras.random.SeedGenerator]] = None,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,7 +73,7 @@ class RankingMetric(keras.metrics.Mean, abc.ABC):
         self,
         y_true: types.Tensor,
         y_pred: types.Tensor,
-        sample_weight: Optional[types.Tensor] = None,
+        sample_weight: types.Tensor | None = None,
     ) -> None:
         """
         Accumulates statistics for the ranking metric.

--- a/keras_rs/src/metrics/ranking_metrics_utils.py
+++ b/keras_rs/src/metrics/ranking_metrics_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import keras
 from keras import ops
@@ -8,9 +8,9 @@ from keras_rs.src import types
 
 def get_shuffled_indices(
     shape: types.Shape,
-    mask: Optional[types.Tensor] = None,
+    mask: types.Tensor | None = None,
     shuffle_ties: bool = True,
-    seed: Optional[Union[int, keras.random.SeedGenerator]] = None,
+    seed: int | keras.random.SeedGenerator | None = None,
 ) -> types.Tensor:
     """Utility function for getting shuffled indices, with masked indices
     pushed to the end.
@@ -54,10 +54,10 @@ def get_shuffled_indices(
 def sort_by_scores(
     tensors_to_sort: list[types.Tensor],
     scores: types.Tensor,
-    mask: Optional[types.Tensor] = None,
-    k: Optional[int] = None,
+    mask: types.Tensor | None = None,
+    k: int | None = None,
     shuffle_ties: bool = True,
-    seed: Optional[Union[int, keras.random.SeedGenerator]] = None,
+    seed: int | keras.random.SeedGenerator | None = None,
 ) -> types.Tensor:
     """
     Utility function for sorting tensors by scores.

--- a/keras_rs/src/metrics/utils.py
+++ b/keras_rs/src/metrics/utils.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from keras import ops
 
 from keras_rs.src import types
@@ -10,9 +8,9 @@ from keras_rs.src.utils.keras_utils import check_shapes_compatible
 def standardize_call_inputs_ranks(
     y_true: types.Tensor,
     y_pred: types.Tensor,
-    mask: Optional[types.Tensor] = None,
+    mask: types.Tensor | None = None,
     check_y_true_rank: bool = True,
-) -> tuple[types.Tensor, types.Tensor, Optional[types.Tensor], bool]:
+) -> tuple[types.Tensor, types.Tensor, types.Tensor | None, bool]:
     """
     Utility function for processing inputs for losses and metrics.
 

--- a/keras_rs/src/types.py
+++ b/keras_rs/src/types.py
@@ -1,15 +1,6 @@
 """Type definitions."""
 
-from typing import (
-    Any,
-    Callable,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Mapping, Sequence, TypeAlias, TypeVar
 
 import keras
 
@@ -19,51 +10,46 @@ A tensor in any of the backends.
 We do not define it explicitly to not require all the backends to be installed
 and imported. The explicit definition would be:
 ```
-Union[
-  numpy.ndarray,
-  tensorflow.Tensor,
-  tensorflow.RaggedTensor,
-  tensorflow.SparseTensor,
-  tensorflow.IndexedSlices,
-  jax.Array,
-  jax.experimental.sparse.JAXSparse,
-  torch.Tensor,
-  keras.KerasTensor,
-]
+numpy.ndarray,
+| tensorflow.Tensor,
+| tensorflow.RaggedTensor,
+| tensorflow.SparseTensor,
+| tensorflow.IndexedSlices,
+| jax.Array,
+| jax.experimental.sparse.JAXSparse,
+| torch.Tensor,
+| keras.KerasTensor,
 ```
 """
-Tensor = Any
+Tensor: TypeAlias = Any
 
-Shape = Sequence[Optional[int]]
-TensorShape = Shape
+Shape: TypeAlias = Sequence[int | None]
 
-DType = str
+DType: TypeAlias = str
 
-ConstraintLike = Union[
-    str,
-    keras.constraints.Constraint,
-    Type[keras.constraints.Constraint],
-    Callable[[Tensor], Tensor],
-]
+ConstraintLike: TypeAlias = (
+    str
+    | keras.constraints.Constraint
+    | type[keras.constraints.Constraint]
+    | Callable[[Tensor], Tensor]
+)
 
-InitializerLike = Union[
-    str,
-    keras.initializers.Initializer,
-    Type[keras.initializers.Initializer],
-    Callable[[Shape, DType], Tensor],
-    Tensor,
-]
+InitializerLike: TypeAlias = (
+    str
+    | keras.initializers.Initializer
+    | type[keras.initializers.Initializer]
+    | Callable[[Shape, DType], Tensor]
+    | Tensor
+)
 
-RegularizerLike = Union[
-    str,
-    keras.regularizers.Regularizer,
-    Type[keras.regularizers.Regularizer],
-    Callable[[Tensor], Tensor],
-]
+RegularizerLike: TypeAlias = (
+    str
+    | keras.regularizers.Regularizer
+    | type[keras.regularizers.Regularizer]
+    | Callable[[Tensor], Tensor]
+)
 
 T = TypeVar("T")
-Nested = Union[
-    T,
-    Sequence[Union[T, "Nested[T]"]],
-    Mapping[str, Union[T, "Nested[T]"]],
-]
+Nested: TypeAlias = (
+    T | Sequence[T | "Nested[T]"] | Mapping[str, T | "Nested[T]"]
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ single-line-exclusions = ["typing"]
 known-first-party = ["keras_rs"]
 
 [tool.mypy]
+python_version = "3.10"
 strict = "True"
 exclude = ["_test\\.py$", "^examples/"]
 untyped_calls_exclude = ["ml_dtypes"]


### PR DESCRIPTION
Now that we require Python 3.10, we can use the shorter annotation style, which should improve the readability of the documentation.