### PR TITLE
Add ragged support for default_device placement on JAX.

### DIFF
--- a/keras_rs/src/layers/embedding/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding_test.py
@@ -214,13 +214,6 @@ class DistributedEmbeddingTest(testing.TestCase, parameterized.TestCase):
         if keras.backend.backend() == "jax":
             if input_type == "sparse":
                 self.skipTest("Sparse inputs not supported on JAX.")
-            if input_type == "ragged" and (
-                placement == "default_device" or not self.on_tpu
-            ):
-                self.skipTest(
-                    "Ragged inputs not supported on JAX with default device "
-                    "placement."
-                )
         elif keras.backend.backend() != "tensorflow":
             if input_type in ("ragged", "sparse"):
                 self.skipTest(
@@ -287,12 +280,6 @@ class DistributedEmbeddingTest(testing.TestCase, parameterized.TestCase):
     )
     def test_model_fit(self, input_type, use_weights):
         if keras.backend.backend() == "jax":
-            if input_type == "ragged" and (
-                self.placement == "default" or not self.on_tpu
-            ):
-                self.skipTest(
-                    f"TODO {input_type} inputs on JAX with default placement."
-                )
             if input_type == "sparse":
                 self.skipTest("TODO sparse inputs on JAX.")
         elif keras.backend.backend() != "tensorflow":
@@ -455,12 +442,6 @@ class DistributedEmbeddingTest(testing.TestCase, parameterized.TestCase):
         self, combiner, input_type, input_rank, use_weights, jit_compile
     ):
         if keras.backend.backend() == "jax":
-            if input_type == "ragged" and (
-                self.placement == "default" or not self.on_tpu
-            ):
-                self.skipTest(
-                    f"TODO {input_type} inputs on JAX with default placement."
-                )
             if input_type == "sparse":
                 self.skipTest(f"TODO {input_type} inputs on JAX.")
         elif keras.backend.backend() == "tensorflow":

--- a/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
@@ -313,11 +313,6 @@ class DistributedEmbeddingLayerTest(parameterized.TestCase):
         table_stacking: str | list[str] | list[list[str]],
         jit: bool,
     ):
-        if ragged and not test_utils.has_sparsecores():
-            self.skipTest(
-                "Ragged inputs are only supported on sparsecore devices."
-            )
-
         table_configs = keras_test_utils.create_random_table_configs(
             combiner=combiner, seed=10
         )
@@ -383,11 +378,6 @@ class DistributedEmbeddingLayerTest(parameterized.TestCase):
         ragged: bool,
         table_stacking: str | list[str] | list[list[str]],
     ):
-        if ragged and not test_utils.has_sparsecores():
-            self.skipTest(
-                "Ragged inputs are only supported on sparsecore devices."
-            )
-
         # Set global distribution to ensure optimizer variables are
         # replicated across all devices by default.
         keras.distribution.set_distribution(keras.distribution.DataParallel())
@@ -401,6 +391,7 @@ class DistributedEmbeddingLayerTest(parameterized.TestCase):
         feature_configs = keras_test_utils.create_random_feature_configs(
             table_configs=table_configs,
             batch_size=16,
+            max_ids_per_sample=20,
             seed=20,
         )
 


### PR DESCRIPTION
Requires calling `preprocess`.

Internally, we currently convert ragged inputs to dense before passing to the embedding call(...) function.