### PR TITLE
Replace leftover `unflatten_as` to `pack_sequence_as`.

### DIFF
--- a/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
@@ -496,7 +496,7 @@ class EmbeddingLookupTest(parameterized.TestCase):
         )
 
         # Generate random dense matrices for use in a predict function.
-        keys = keras.tree.unflatten_as(
+        keys = keras.tree.pack_sequence_as(
             feature_specs,
             jnp.unstack(
                 jax.random.split(


### PR DESCRIPTION
This instance was missed as it is only run on TPU.