### PR TITLE
Check for jax_tpu_embedding on JAX backend.

### DIFF
--- a/keras_rs/src/layers/embedding/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding.py
@@ -1,3 +1,4 @@
+import importlib.util
 import platform
 import sys
 
@@ -5,11 +6,14 @@ import keras
 
 from keras_rs.src.api_export import keras_rs_export
 
-# JAX TPU embedding is only available on linux_x86_64.
+# JAX distributed embedding is only available on linux_x86_64, and only if
+# jax-tpu-embedding is installed.
+jax_tpu_embedding_spec = importlib.util.find_spec("jax_tpu_embedding")
 if (
     keras.backend.backend() == "jax"
     and sys.platform == "linux"
     and platform.machine().lower() == "x86_64"
+    and jax_tpu_embedding_spec is not None
 ):
     from keras_rs.src.layers.embedding.jax.distributed_embedding import (
         DistributedEmbedding as BackendDistributedEmbedding,

--- a/keras_rs/src/layers/embedding/jax/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding.py
@@ -347,12 +347,6 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
 
         return table_variable, slot_variables
 
-    def _has_sparsecore(self) -> bool:
-        device_kind = jax.devices()[0].device_kind
-        if device_kind in ["TPU v5", "TPU v6 lite"]:
-            return True
-        return False
-
     @keras_utils.no_automatic_dependency_tracking
     def _sparsecore_init(
         self,


### PR DESCRIPTION
This is to allow users to potentially run Keras RS _without_ the dependency.

If a user doesn't have `jax-tpu-embedding` installed, but are on `linux_x86_64` and has a sparsecore-capable TPU available, and if they try to use `auto` or `sparsecore` placement with distributed embedding, will raise an error informing them to install the dependency.