### PR TITLE
Fix docstring for `DistributedEmbedding`.

### DIFF
--- a/keras_rs/src/layers/embedding/base_distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/base_distributed_embedding.py
@@ -297,6 +297,7 @@ class DistributedEmbedding(keras.layers.Layer):
             result = strategy.run(step, args=(next(iterator),))
 
     run_loop(iter(dataset))
+    ```
 
     ### Usage with JAX on TPU with SpareCore
 


### PR DESCRIPTION
The JAX usage section was broken.