### PR TITLE
Fix for removal of JAX `DeviceLocalLayout`.

### DIFF
--- a/keras_rs/src/layers/embedding/jax/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding.py
@@ -219,7 +219,7 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
         LayoutClass = (
             jax_layout.Layout
             if jax.__version_info__ >= (0, 6, 3)
-            else jax_layout.DeviceLocalLayout
+            else jax_layout.DeviceLocalLayout  # type: ignore
         )
         # pylint: disable-next=protected-access
         sparsecore_layout._backend_layout = jax_layout.Format(

--- a/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
@@ -44,7 +44,7 @@ def _create_sparsecore_layout(
     LayoutClass = (
         jax_layout.Layout
         if jax.__version_info__ >= (0, 6, 3)
-        else jax_layout.DeviceLocalLayout
+        else jax_layout.DeviceLocalLayout  # type: ignore
     )
     # pylint: disable-next=protected-access
     sparsecore_layout._backend_layout = jax_layout.Format(


### PR DESCRIPTION
Type verification fails after removal.