### PR TITLE
DistributedEmbedding: do not hardcode the number of SparseCores with TF.

### DIFF
--- a/keras_rs/src/layers/embedding/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding_test.py
@@ -611,7 +611,9 @@ class DistributedEmbeddingTest(testing.TestCase, parameterized.TestCase):
 
         self.assertEqual(res.shape, (self.batch_size, EMBEDDING_OUTPUT_DIM))
 
-        tables = layer.get_embedding_tables()
+        with self._strategy.scope():
+            tables = layer.get_embedding_tables()
+
         emb = tables["table"]
 
         if input_type == "dense":


### PR DESCRIPTION
The number of SparseCore chips per TPU is now retrieved from the strategy. This makes the `distributed_embedding_tests.py` pass on V6e.