### PR TITLE
Bump Python, JAX and Tensorflow versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,10 +22,10 @@ jobs:
       KERAS_BACKEND: ${{ matrix.backend }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,15 @@ authors = [
 ]
 description = "Multi-backend recommender systems with Keras 3."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "Apache License 2.0"}
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Operating System :: Unix",
     "Operating System :: Microsoft :: Windows",

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version.
-tensorflow-cpu
+tensorflow-cpu>=2.20.0
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu
@@ -8,7 +8,7 @@ torch>=2.1.0
 # Jax with cuda support.
 # Keep same version as Keras repo.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12]==0.6.2
+jax[cuda12]>=0.7.0
 
 # Support for large embeddings.
 jax-tpu-embedding;sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow with cuda support.
-tensorflow[and-cuda]~=2.17.0
+tensorflow[and-cuda]
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version.
-tensorflow-cpu~=2.17
+tensorflow-cpu
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Tensorflow.
-tensorflow-cpu~=2.18.0;sys_platform != 'darwin'
-tensorflow~=2.18.0;sys_platform == 'darwin'
+tensorflow-cpu>=2.20.0;sys_platform != 'darwin'
+tensorflow>=2.20.0;sys_platform == 'darwin'
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.1.0
 
 # Jax.
-jax[cpu]>=0.6.2
+jax[cpu]>=0.7.0
 jax-tpu-embedding;sys_platform == 'linux' and platform_machine == 'x86_64'
 
 # pre-commit checks (formatting, linting, etc.)


### PR DESCRIPTION
- `jax-tpu-embedding` now requires `jax>=0.7.0`.
- `jax>=0.7.0` requires Python 3.11
- `jax-tpu-embedding` also requires a more recent version of `protobuf` than what comes with Tensorflow 2.18 and 2.19, requiring an upgrade to 2.20.