### PR TITLE
Refactor: Use `embedding.EmbeddingVariables` in Keras-RS JAX embedding tests.

### DIFF
--- a/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
+++ b/keras_rs/src/layers/embedding/jax/embedding_lookup_test.py
@@ -193,7 +193,7 @@ class EmbeddingLookupTest(parameterized.TestCase):
 
         # Add pseudo gradients to the inputs.
         embedding_variables = jax.tree.map(
-            lambda table: (table, None),
+            lambda table: embedding.EmbeddingVariables(table=table, slot=()),
             sharded_tables,
         )
 
@@ -288,7 +288,7 @@ class EmbeddingLookupTest(parameterized.TestCase):
 
         # Add pseudo gradients to the inputs.
         embedding_variables = jax.tree.map(
-            lambda table: (table, None),
+            lambda table: embedding.EmbeddingVariables(table=table, slot=()),
             sharded_tables,
         )
 
@@ -479,7 +479,8 @@ class EmbeddingLookupTest(parameterized.TestCase):
             )
         )
         sharded_table_and_slot_variables = typing.cast(
-            dict[str, tuple[jax.Array, ...]], sharded_table_and_slot_variables
+            dict[str, embedding.EmbeddingVariables],
+            sharded_table_and_slot_variables,
         )
 
         # Shard samples for lookup query.


### PR DESCRIPTION
This change updates the Keras-RS JAX embedding tests to use the `embedding.EmbeddingVariables` dataclass from `jax_tpu_embedding` for representing embedding tables and slot variables, instead of a custom tuple structure. This involves updating type hints, variable access, and build dependencies.