### PR TITLE
Unwrap variables before passing to `jax.jit`.

### DIFF
--- a/keras_rs/src/layers/embedding/distributed_embedding_test.py
+++ b/keras_rs/src/layers/embedding/distributed_embedding_test.py
@@ -598,8 +598,8 @@ class DistributedEmbeddingTest(testing.TestCase, parameterized.TestCase):
                         non_trainable_layouts,
                     ),
                 )(
-                    layer.trainable_variables,
-                    layer.non_trainable_variables,
+                    [v.value for v in layer.trainable_variables],
+                    [v.value for v in layer.non_trainable_variables],
                     preprocessed,
                 )
             else:


### PR DESCRIPTION
Passing `__jax_array__`-implementing objects directly to `jax.jit` will no longer be supported.