### PR TITLE
Use the JTE API to set stacked table stats...

### DIFF
--- a/keras_rs/src/layers/embedding/jax/distributed_embedding.py
+++ b/keras_rs/src/layers/embedding/jax/distributed_embedding.py
@@ -464,17 +464,14 @@ class DistributedEmbedding(base_distributed_embedding.DistributedEmbedding):
             )
 
             # Only set the suggested buffer size if set on any individual table.
-            suggested_buffer_sizes = np.asarray(
-                [
-                    s.suggested_coo_buffer_size_per_device
-                    for s in stack
-                    if s.suggested_coo_buffer_size_per_device is not None
-                ],
-                dtype=np.int32,
-            )
-            if len(suggested_buffer_sizes) > 0:
+            valid_buffer_sizes = [
+                s.suggested_coo_buffer_size_per_device
+                for s in stack
+                if s.suggested_coo_buffer_size_per_device is not None
+            ]
+            if valid_buffer_sizes:
                 required_buffer_size_per_device[stack_name] = np.max(
-                    suggested_buffer_sizes
+                    np.asarray(valid_buffer_sizes, dtype=np.int32)
                 )
 
             id_drop_counters[stack_name] = 0


### PR DESCRIPTION
… to the maximum of the input table specs.

This allows setting parameters like `max_ids_per_partition` and `max_unique_ids_per_partition`, `suggested_coo_buffer_size` for stacked tables with auto-stacking.

Although the heuristic may not be optimal, this at least provides a method for directly setting the values in the stacked tables, and is consistent with the default values if nothing is set.

Uses the `jax_tpu_embedding` API for future-proofing.