### PR TITLE
Do the nightly build only if there has been commits.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,11 +9,32 @@ permissions:
   contents: read
 
 jobs:
+  check_commits:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      has_recent_commits: ${{ steps.check.outputs.has_recent_commits }}
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v4
+      - id: check
+        run: |
+          # Check for commits in the last 25 hours (use a 1 hour margin)
+          if [ -z "$(git rev-list --after="25 hours" ${{ github.sha }})" ]; then
+            echo "has_recent_commits=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_recent_commits=true" >> $GITHUB_OUTPUT
+          fi
+
   run-test-for-nightly:
+    needs: [check_commits]
+    if: ${{needs.check_commits.outputs.has_recent_commits == true}}
     uses: ./.github/workflows/actions.yml
+
   nightly:
     name: Build Wheel file and upload
-    needs: [run-test-for-nightly]
+    needs: [check_commits, run-test-for-nightly]
+    if: ${{needs.check_commits.outputs.has_recent_commits == true}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add a check to verify if there are recent commits to actually perform the nightly build:
- We use a 25 hour window instead of 24 hour to avoid race conditions for commits right around the limit.
- Note that `actions/checkout` only checks out the last commit with no history, but it's not an issue as the `git rev-list --after="25 hours` command return that one commit if it's less that 25 hours old and nothing otherwise.