### PR TITLE
Configure concurrency for test workflows.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   run_cpu_tests:
     name: Test the code on CPU


### PR DESCRIPTION
This way, if more code is pushed to an existing PR with tests running, the old tests are cancelled when the new tests are triggered.

For `pull`s we don't want to cancel any tests. The achieve this by not having the same group thanks to the unique `github.run_id`.

`github.head_ref` is only populated for `pull_request`, so those will be deduped for the same PR.