### PR TITLE
Refactor CI: Extract CPU, GPU, and TPU tests into standalone reusable workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
   pull_request:
-  workflow_call:
   release:
     types: [created]
 
@@ -15,126 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_cpu_tests:
-    name: Test the code on CPU
-    runs-on: linux-x86-n2-16
+  cpu_tests:
+    uses: ./.github/workflows/cpu_tests.yml # zizmor: ignore[self-repository]
 
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [tensorflow, jax, torch]
+  gpu_tests:
+    uses: ./.github/workflows/gpu_tests.yml # zizmor: ignore[self-repository]
 
-    container:
-      image: python:3.11-slim
-      options: --privileged --network host
-
-    env:
-      KERAS_BACKEND: ${{ matrix.backend }}
-
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-
-    - name: Install Dependencies
-      run: pip install --no-cache-dir -r requirements.txt
-
-    - name: Test with pytest
-      run: pytest keras_rs/
-
-  run_gpu_tests:
-    name: Test the code on GPU
-    runs-on: linux-x86-g2-16-l4-1gpu
-
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [tensorflow, jax, torch]
-
-    container:
-      image: python:3.11-slim
-      options: --privileged --network host
-
-    env:
-      KERAS_BACKEND: ${{ matrix.backend }}
-
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-
-    - name: Check CUDA Version
-      run: nvidia-smi
-
-    - name: Install Dependencies
-      run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-cuda.txt
-
-    - name: Verify TF Installation
-      if: ${{ matrix.backend == 'tensorflow'}}
-      run: python3 -c "import tensorflow as tf; print('Tensorflow devices:', tf.config.list_logical_devices()); assert len(tf.config.list_physical_devices('GPU')) > 0"
-
-    - name: Verify JAX Installation
-      if: ${{ matrix.backend == 'jax'}}
-      run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'gpu'"
-
-    - name: Verify Torch Installation
-      if: ${{ matrix.backend == 'torch'}}
-      run: python3 -c "import torch; print('Torch devices:', [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]); assert torch.cuda.device_count() > 0"
-
-    - name: Test with pytest
-      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax
-
-  run_tpu_tests:
-    name: Test the code on TPU
-    runs-on: linux-x86-ct6e-44-1tpu
-
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [tensorflow, jax]
-
-    container:
-      image: python:3.11-slim
-      options: --privileged --network host
-
-    env:
-      KERAS_BACKEND: ${{ matrix.backend }}
-      TPU_NAME: local
-
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-
-    - name: Install Dependencies
-      run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-tpu.txt
-
-    - name: Set TF Specific Environment Variables
-      if: ${{ matrix.backend == 'tensorflow'}}
-      run: |
-        echo "PJRT_DEVICE=TPU" >> $GITHUB_ENV
-        echo "NEXT_PLUGGABLE_DEVICE_USE_C_API=true" >> $GITHUB_ENV
-        echo "TF_XLA_FLAGS=--tf_mlir_enable_mlir_bridge=true" >> $GITHUB_ENV
-        pip show libtpu | grep "^Location: " | sed "s/^Location: \(.*\)$/TF_PLUGGABLE_DEVICE_LIBRARY_PATH=\1\/libtpu\/libtpu.so/1" >> $GITHUB_ENV
-
-    - name: Verify TF Installation
-      if: ${{ matrix.backend == 'tensorflow'}}
-      run: python3 -c "import tensorflow as tf; print('Tensorflow devices:', tf.config.list_logical_devices()); assert len(tf.config.list_physical_devices('TPU')) > 0"
-
-    - name: Verify JAX Installation
-      if: ${{ matrix.backend == 'jax'}}
-      run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'tpu'"
-
-    - name: Test with pytest (TensorFlow)
-      if: ${{ matrix.backend == 'tensorflow' }}
-      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax
-
-    - name: Test with pytest (JAX)
-      if: ${{ matrix.backend == 'jax' }}
-      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax/distributed_embedding_test.py
+  tpu_tests:
+    uses: ./.github/workflows/tpu_tests.yml # zizmor: ignore[self-repository]
 
   check_format:
     name: Check the code format

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -1,0 +1,42 @@
+name: CPU Tests
+
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        description: 'Timeout in minutes for each test job'
+        type: number
+        default: 120
+
+permissions:
+  contents: read
+
+jobs:
+  cpu_tests:
+    name: CPU Tests (${{ matrix.backend }})
+    runs-on: linux-x86-n2-16
+    timeout-minutes: ${{ inputs.timeout }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+
+    container:
+      image: python:3.11-slim
+      options: --privileged --network host
+
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Install Dependencies
+      run: pip install --no-cache-dir -r requirements.txt
+
+    - name: Test with pytest
+      run: pytest keras_rs/

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -1,0 +1,57 @@
+name: GPU Tests
+
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        description: 'Timeout in minutes for each test job'
+        type: number
+        default: 120
+
+permissions:
+  contents: read
+
+jobs:
+  gpu_tests:
+    name: GPU Tests (${{ matrix.backend }})
+    runs-on: linux-x86-g2-16-l4-1gpu
+    timeout-minutes: ${{ inputs.timeout }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+
+    container:
+      image: python:3.11-slim
+      options: --privileged --network host
+
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Check CUDA Version
+      run: nvidia-smi
+
+    - name: Install Dependencies
+      run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-cuda.txt
+
+    - name: Verify TF Installation
+      if: ${{ matrix.backend == 'tensorflow'}}
+      run: python3 -c "import tensorflow as tf; print('Tensorflow devices:', tf.config.list_logical_devices()); assert len(tf.config.list_physical_devices('GPU')) > 0"
+
+    - name: Verify JAX Installation
+      if: ${{ matrix.backend == 'jax'}}
+      run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'gpu'"
+
+    - name: Verify Torch Installation
+      if: ${{ matrix.backend == 'torch'}}
+      run: python3 -c "import torch; print('Torch devices:', [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]); assert torch.cuda.device_count() > 0"
+
+    - name: Test with pytest
+      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,14 +28,16 @@ jobs:
             echo "has_recent_commits=true" >> $GITHUB_OUTPUT
           fi
 
-  run-test-for-nightly:
+  cpu_tests:
     needs: [check_commits]
     if: ${{needs.check_commits.outputs.has_recent_commits == 'true'}}
-    uses: ./.github/workflows/actions.yml  # zizmor: ignore[self-repository]
+    uses: ./.github/workflows/cpu_tests.yml  # zizmor: ignore[self-repository]
+    with:
+      timeout: 240
 
   nightly:
     name: Build Wheel file and upload
-    needs: [check_commits, run-test-for-nightly]
+    needs: [check_commits, cpu_tests]
     if: ${{needs.check_commits.outputs.has_recent_commits == 'true'}}
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -1,0 +1,64 @@
+name: TPU Tests
+
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        description: 'Timeout in minutes for each test job'
+        type: number
+        default: 120
+
+permissions:
+  contents: read
+
+jobs:
+  tpu_tests:
+    name: TPU Tests (${{ matrix.backend }})
+    runs-on: linux-x86-ct6e-44-1tpu
+    timeout-minutes: ${{ inputs.timeout }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax]
+
+    container:
+      image: python:3.11-slim
+      options: --privileged --network host
+
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+      TPU_NAME: local
+
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Install Dependencies
+      run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-tpu.txt
+
+    - name: Set TF Specific Environment Variables
+      if: ${{ matrix.backend == 'tensorflow'}}
+      run: |
+        echo "PJRT_DEVICE=TPU" >> $GITHUB_ENV
+        echo "NEXT_PLUGGABLE_DEVICE_USE_C_API=true" >> $GITHUB_ENV
+        echo "TF_XLA_FLAGS=--tf_mlir_enable_mlir_bridge=true" >> $GITHUB_ENV
+        pip show libtpu | grep "^Location: " | sed "s/^Location: \(.*\)$/TF_PLUGGABLE_DEVICE_LIBRARY_PATH=\1\/libtpu\/libtpu.so/1" >> $GITHUB_ENV
+
+    - name: Verify TF Installation
+      if: ${{ matrix.backend == 'tensorflow'}}
+      run: python3 -c "import tensorflow as tf; print('Tensorflow devices:', tf.config.list_logical_devices()); assert len(tf.config.list_physical_devices('TPU')) > 0"
+
+    - name: Verify JAX Installation
+      if: ${{ matrix.backend == 'jax'}}
+      run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'tpu'"
+
+    - name: Test with pytest (TensorFlow)
+      if: ${{ matrix.backend == 'tensorflow' }}
+      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax
+
+    - name: Test with pytest (JAX)
+      if: ${{ matrix.backend == 'jax' }}
+      run: pytest keras_rs/ --ignore=keras_rs/src/layers/embedding/jax/distributed_embedding_test.py


### PR DESCRIPTION
## What this PR does

Extracts the CPU, GPU, and TPU test jobs from `actions.yml` into standalone
reusable `workflow_call` workflows so they can be called independently by
different workflows with different configurations.

### Files Changed

| File | Action | Description |
|------|--------|-------------|
| `.github/workflows/cpu_tests.yml` | NEW | Reusable workflow with the CPU test job |
| `.github/workflows/gpu_tests.yml` | NEW | Reusable workflow with the GPU test job |
| `.github/workflows/tpu_tests.yml` | NEW | Reusable workflow with the TPU test job |
| `.github/workflows/actions.yml` | MODIFIED | Now delegates to reusable workflows instead of defining tests inline |
| `.github/workflows/nightly.yml` | MODIFIED | Calls `cpu_tests.yml` directly (with extended timeout) instead of going through `actions.yml` |

### Behavior

- **PR / push to main**: Runs CPU + GPU + TPU + format check (all via `actions.yml`)
- **Nightly**: Runs only CPU tests (via `cpu_tests.yml` with `timeout: 240`) → builds & publishes wheel

### Why

- Keeps `actions.yml` as a thin orchestrator
- Each test suite can be called independently with custom parameters (e.g., timeout)
- Nightly no longer wastes GPU/TPU resources — only runs CPU tests before publishing
- Follows the same pattern used in KerasHub and Keras
